### PR TITLE
feat(post): add draft functionality

### DIFF
--- a/src/models.lisp
+++ b/src/models.lisp
@@ -5,15 +5,16 @@
    (user-id :accessor post-user-id :initarg :user-id)
    (title :accessor post-title :initarg :title)
    (content :accessor post-content :initarg :content)
+   (status :accessor post-status :initarg :status)
    (author-name :accessor post-author-name :initarg :author-name)
    (created-at :accessor post-created-at :initarg :created-at)
    (updated-at :accessor post-updated-at :initarg :updated-at)))
 
 (defun get-all-posts ()
-  "全ての投稿を取得（著者情報付き）"
+  "全ての投稿を取得（著者情報付き、statusカラム含む）"
   (with-db
-    (let ((posts (query "SELECT p.id, p.user_id, p.title, p.content, 
-                                u.display_name, p.created_at, p.updated_at
+    (let ((posts (query "SELECT p.id, p.user_id, p.title, p.content,
+                                u.display_name, p.created_at, p.updated_at, p.status
                          FROM posts p
                          JOIN users u ON p.user_id = u.id
                          ORDER BY p.created_at DESC")))
@@ -25,18 +26,40 @@
                                :content (nth 3 post)
                                :author-name (nth 4 post)
                                :created-at (nth 5 post)
-                               :updated-at (nth 6 post)))
+                               :updated-at (nth 6 post)
+                               :status (nth 7 post)))
+              posts))))
+
+(defun get-published-posts ()
+  "公開済みの投稿のみを取得（一般ユーザー向け）"
+  (with-db
+    (let ((posts (query "SELECT p.id, p.user_id, p.title, p.content,
+                                u.display_name, p.created_at, p.updated_at, p.status
+                         FROM posts p
+                         JOIN users u ON p.user_id = u.id
+                         WHERE p.status = 'published'
+                         ORDER BY p.created_at DESC")))
+      (mapcar (lambda (post)
+                (make-instance 'post
+                               :id (nth 0 post)
+                               :user-id (nth 1 post)
+                               :title (nth 2 post)
+                               :content (nth 3 post)
+                               :author-name (nth 4 post)
+                               :created-at (nth 5 post)
+                               :updated-at (nth 6 post)
+                               :status (nth 7 post)))
               posts))))
 
 (defun get-post-by-id (id)
-  "IDで投稿を取得"
+  "IDで投稿を取得（statusカラム含む）"
   (with-db
-    (let ((post (query "SELECT p.id, p.user_id, p.title, p.content, 
-                               u.display_name, p.created_at, p.updated_at
+    (let ((post (query "SELECT p.id, p.user_id, p.title, p.content,
+                               u.display_name, p.created_at, p.updated_at, p.status
                         FROM posts p
                         JOIN users u ON p.user_id = u.id
-                        WHERE p.id = $1" 
-                       id :row)))  ; :single を :row に変更
+                        WHERE p.id = $1"
+                       id :row)))
       (when post
         (make-instance 'post
                        :id (nth 0 post)
@@ -45,7 +68,8 @@
                        :content (nth 3 post)
                        :author-name (nth 4 post)
                        :created-at (nth 5 post)
-                       :updated-at (nth 6 post))))))
+                       :updated-at (nth 6 post)
+                       :status (nth 7 post))))))
 
 
 
@@ -56,14 +80,14 @@
 
 
 (defun get-posts-by-user (user-id)
-  "特定ユーザーの投稿を取得"
+  "特定ユーザーの投稿を取得（下書き含む、本人のみアクセス可能）"
   (with-db
-    (let ((posts (query "SELECT p.id, p.user_id, p.title, p.content, 
-                                u.display_name, p.created_at, p.updated_at
+    (let ((posts (query "SELECT p.id, p.user_id, p.title, p.content,
+                                u.display_name, p.created_at, p.updated_at, p.status
                          FROM posts p
                          JOIN users u ON p.user_id = u.id
                          WHERE p.user_id = $1
-                         ORDER BY p.created_at DESC" 
+                         ORDER BY p.created_at DESC"
                         user-id)))
       (mapcar (lambda (post)
                 (make-instance 'post
@@ -73,33 +97,69 @@
                                :content (nth 3 post)
                                :author-name (nth 4 post)
                                :created-at (nth 5 post)
-                               :updated-at (nth 6 post)))
+                               :updated-at (nth 6 post)
+                               :status (nth 7 post)))
               posts))))
 
-(defun create-post (user-id title content)
-  "新しい投稿を作成"
+(defun get-user-drafts (user-id)
+  "特定ユーザーの下書きのみを取得"
   (with-db
-    (execute "INSERT INTO posts (user_id, title, content) VALUES ($1, $2, $3)"
-             user-id title content)))
+    (let ((posts (query "SELECT p.id, p.user_id, p.title, p.content,
+                                u.display_name, p.created_at, p.updated_at, p.status
+                         FROM posts p
+                         JOIN users u ON p.user_id = u.id
+                         WHERE p.user_id = $1 AND p.status = 'draft'
+                         ORDER BY p.created_at DESC"
+                        user-id)))
+      (mapcar (lambda (post)
+                (make-instance 'post
+                               :id (nth 0 post)
+                               :user-id (nth 1 post)
+                               :title (nth 2 post)
+                               :content (nth 3 post)
+                               :author-name (nth 4 post)
+                               :created-at (nth 5 post)
+                               :updated-at (nth 6 post)
+                               :status (nth 7 post)))
+              posts))))
 
-(defun update-post (post-id user-id title content)
-  "投稿を更新（作成者のみ）"
+(defun create-post (user-id title content &optional (status "published"))
+  "新しい投稿を作成（status指定可能、デフォルトは公開）"
   (with-db
-    (let ((affected (execute "UPDATE posts 
-                              SET title = $3, content = $4, updated_at = NOW()
-                              WHERE id = $1 AND user_id = $2"
-                             post-id user-id title content)))
+    (execute "INSERT INTO posts (user_id, title, content, status) VALUES ($1, $2, $3, $4)"
+             user-id title content status)))
+
+(defun update-post (post-id user-id title content &optional status)
+  "投稿を更新（作成者のみ、status変更可能）"
+  (with-db
+    (let ((affected (if status
+                        (execute "UPDATE posts
+                                  SET title = $3, content = $4, status = $5, updated_at = NOW()
+                                  WHERE id = $1 AND user_id = $2"
+                                 post-id user-id title content status)
+                        (execute "UPDATE posts
+                                  SET title = $3, content = $4, updated_at = NOW()
+                                  WHERE id = $1 AND user_id = $2"
+                                 post-id user-id title content))))
       (> affected 0))))
 
-(defun get-post-by-id (post-id)
-  "IDで投稿を取得（存在確認用）"
+(defun publish-draft (post-id user-id)
+  "下書きを公開状態に変更（作成者のみ）"
   (with-db
-    (let ((result (query "SELECT id, user_id, title FROM posts WHERE id = $1"
-                         post-id :row)))
-      (when result
-        (list :id (nth 0 result)
-              :user-id (nth 1 result)
-              :title (nth 2 result))))))
+    (let ((affected (execute "UPDATE posts
+                              SET status = 'published', updated_at = NOW()
+                              WHERE id = $1 AND user_id = $2 AND status = 'draft'"
+                             post-id user-id)))
+      (> affected 0))))
+
+(defun unpublish-post (post-id user-id)
+  "公開記事を下書きに戻す（作成者のみ）"
+  (with-db
+    (let ((affected (execute "UPDATE posts
+                              SET status = 'draft', updated_at = NOW()
+                              WHERE id = $1 AND user_id = $2 AND status = 'published'"
+                             post-id user-id)))
+      (> affected 0))))
 
 (defun delete-post (post-id user-id)
   "投稿を削除（作成者のみ）"


### PR DESCRIPTION
## 概要 / Summary

投稿機能に下書き機能を追加しました。

## 実装内容 / Implementation Details

### 📊 データベース変更
- `posts`テーブルに`status`カラムを追加
- `draft`（下書き）と`published`（公開済み）の2つのステータス
- 既存データは自動的に`published`として設定される後方互換性の保証
- CHECK制約による適切なバリデーション

### 🔧 モデル層の更新
- `post`クラスに`status`フィールドを追加
- 下書き専用の取得関数を追加:
  - `get-user-drafts`: ユーザーの下書きのみ取得
  - `get-published-posts`: 公開済み投稿のみ取得（既存機能の明確化）
- 下書き公開・非公開の切り替え関数:
  - `publish-draft`: 下書きを公開状態に変更
  - `unpublish-post`: 公開記事を下書きに戻す

### 🌐 API エンドポイントの拡張
- `GET /api/posts?status=draft`: 下書き一覧取得（ログインユーザーのみ）
- `GET /api/posts?status=published`: 公開済み投稿一覧取得
- `POST /api/posts`: 投稿作成時にstatusパラメータ対応
- `PUT /api/posts/:id/publish`: 下書きを公開
- `PUT /api/posts/:id/unpublish`: 公開記事を下書きに戻す

## セキュリティ考慮事項 / Security Considerations

- 下書きは**投稿者本人のみ**アクセス可能
- 未ログインユーザーには下書きは表示されない
- 権限チェックを各エンドポイントで実装

## テスト結果 / Test Results

- ✅ データベース移行成功（既存データ保護確認）
- ✅ サーバー起動・動作確認
- ✅ API エンドポイント応答確認
- ✅ 既存機能への影響なし

## 今後の予定 / Future Plans

フロントエンド（Vue.js）での下書き機能実装が次のステップとなります。

🤖 Claude Code で実装