### PR TITLE
feat(auth): implement dedicated login and signup pages

### DIFF
--- a/docs/login-mockups/blog_login_mock.html
+++ b/docs/login-mockups/blog_login_mock.html
@@ -1,0 +1,290 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>MyBlog - ログイン</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+            height: 100vh;
+            overflow: hidden;
+        }
+
+        .background {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100%;
+            height: 100%;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            background-size: cover;
+            background-position: center;
+            filter: brightness(0.8);
+            z-index: -1;
+        }
+
+        .header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            padding: 20px 40px;
+            position: absolute;
+            top: 0;
+            left: 0;
+            right: 0;
+        }
+
+        .logo {
+            display: flex;
+            align-items: center;
+            gap: 15px;
+        }
+
+        .logo-icon {
+            width: 35px;
+            height: 35px;
+            background: white;
+            border-radius: 8px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: bold;
+            font-size: 20px;
+            color: #667eea;
+        }
+
+        .search-box {
+            background: rgba(255, 255, 255, 0.2);
+            border: none;
+            border-radius: 6px;
+            padding: 8px 15px;
+            color: white;
+            width: 200px;
+            outline: none;
+        }
+
+        .search-box::placeholder {
+            color: rgba(255, 255, 255, 0.7);
+        }
+
+        .signup-btn {
+            background: #00d084;
+            color: white;
+            border: none;
+            padding: 10px 25px;
+            border-radius: 6px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: background 0.3s;
+        }
+
+        .signup-btn:hover {
+            background: #00b872;
+        }
+
+        .container {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            min-height: 100vh;
+            padding: 20px;
+        }
+
+        .login-card {
+            background: white;
+            border-radius: 12px;
+            padding: 50px 40px;
+            width: 100%;
+            max-width: 420px;
+            box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+        }
+
+        .brand-name {
+            text-align: center;
+            font-size: 48px;
+            font-weight: bold;
+            color: #1a1a1a;
+            margin-bottom: 40px;
+            letter-spacing: -1px;
+        }
+
+        .form-group {
+            margin-bottom: 15px;
+        }
+
+        .form-input {
+            width: 100%;
+            padding: 15px;
+            border: 1px solid #e0e0e0;
+            border-radius: 6px;
+            font-size: 15px;
+            transition: border-color 0.3s;
+            outline: none;
+        }
+
+        .form-input:focus {
+            border-color: #667eea;
+        }
+
+        .login-btn {
+            width: 100%;
+            padding: 15px;
+            background: #00d084;
+            color: white;
+            border: none;
+            border-radius: 6px;
+            font-size: 16px;
+            font-weight: 600;
+            cursor: pointer;
+            margin-top: 10px;
+            transition: background 0.3s;
+        }
+
+        .login-btn:hover {
+            background: #00b872;
+        }
+
+        .divider {
+            display: flex;
+            align-items: center;
+            margin: 25px 0;
+            color: #888;
+            font-size: 14px;
+        }
+
+        .divider::before,
+        .divider::after {
+            content: '';
+            flex: 1;
+            border-bottom: 1px solid #e0e0e0;
+        }
+
+        .divider::before {
+            margin-right: 15px;
+        }
+
+        .divider::after {
+            margin-left: 15px;
+        }
+
+        .social-btn {
+            width: 100%;
+            padding: 13px;
+            border: 1px solid #e0e0e0;
+            border-radius: 6px;
+            background: white;
+            font-size: 15px;
+            font-weight: 500;
+            cursor: pointer;
+            margin-bottom: 12px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            gap: 10px;
+            transition: background 0.3s;
+        }
+
+        .social-btn:hover {
+            background: #f8f8f8;
+        }
+
+        .social-icon {
+            width: 20px;
+            height: 20px;
+        }
+
+        .trending-link {
+            text-align: center;
+            margin-top: 25px;
+        }
+
+        .trending-link a {
+            color: #667eea;
+            text-decoration: none;
+            font-size: 14px;
+            font-weight: 500;
+        }
+
+        .trending-link a:hover {
+            text-decoration: underline;
+        }
+
+        .footer {
+            position: fixed;
+            bottom: 20px;
+            left: 40px;
+            display: flex;
+            gap: 20px;
+        }
+
+        .footer a {
+            color: rgba(255, 255, 255, 0.9);
+            text-decoration: none;
+            font-size: 14px;
+        }
+
+        .footer a:hover {
+            text-decoration: underline;
+        }
+
+        .forgot-password {
+            text-align: right;
+            margin-top: 10px;
+        }
+
+        .forgot-password a {
+            color: #667eea;
+            text-decoration: none;
+            font-size: 14px;
+        }
+
+        .forgot-password a:hover {
+            text-decoration: underline;
+        }
+    </style>
+</head>
+<body>
+    <div class="background"></div>
+
+    <div class="header">
+        <div class="logo">
+            <div class="logo-icon">B</div>
+            <input type="text" class="search-box" placeholder="ブログを検索">
+        </div>
+        <button class="signup-btn">新規登録</button>
+    </div>
+
+    <div class="container">
+        <div class="login-card">
+            <h1 class="brand-name">MyBlog</h1>
+            
+            <form>
+                <div class="form-group">
+                    <input type="email" class="form-input" placeholder="メールアドレス" required>
+                </div>
+                
+                <div class="form-group">
+                    <input type="password" class="form-input" placeholder="パスワード" required>
+                </div>
+
+                <div class="forgot-password">
+                    <a href="#">パスワードをお忘れですか？</a>
+                </div>
+                
+                <button type="submit" class="login-btn">ログイン</button>
+            </form>
+
+
+        </div>
+    </div>
+
+
+</body>
+</html>

--- a/src/handlers.lisp
+++ b/src/handlers.lisp
@@ -329,8 +329,8 @@
                                              (:button :class "btn btn-outline" "@click" "logout" "Logout")
                                              (:raw "</template>")
                                              (:raw "<template v-else>")
-                                             (:button :class "btn btn-outline" "@click" "showLoginModal = true" "Login")
-                                             (:button :class "btn btn-gradient" "@click" "showSignupModal = true" "Sign Up")
+                                             (:a :href "/login" :class "btn btn-outline" "Login")
+                                             (:a :href "/signup" :class "btn btn-gradient" "Sign Up")
                                              (:raw "</template>")))
 
                                  ;; Main Container - Create Post View
@@ -409,31 +409,122 @@
                                        (:raw "</div>"))
                                  (:raw "</div>")
 
-                                 ;; Login Modal
-                                 (:raw "<div v-if=\"showLoginModal\" class=\"fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center\" style=\"z-index: 1000;\" @click.self=\"showLoginModal = false\">")
-                                 (:div :class "card" :style "max-width: 400px; width: 100%; margin: 20px;"
-                                       (:h2 :style "font-size: 1.5rem; font-weight: 600; margin-bottom: 20px; color: var(--text-primary);" "Login")
-                                       (:raw "<form @submit.prevent=\"login\">")
-                                       (:input :class "form-control" :style "margin-bottom: 15px;" :v-model "loginForm.username" :placeholder "Username" :required "required")
-                                       (:input :class "form-control" :style "margin-bottom: 15px;" :type "password" :v-model "loginForm.password" :placeholder "Password" :required "required")
-                                       (:div :style "display: flex; gap: 10px;"
-                                             (:button :class "btn btn-gradient" :type "submit" :style "flex: 1;" "Login")
-                                             (:button :class "btn btn-outline" :type "button" :style "flex: 1;" "@click" "showLoginModal = false" "Cancel"))
-                                       (:raw "</form>"))
-                                 (:raw "</div>")
 
-                                 ;; Signup Modal
-                                 (:raw "<div v-if=\"showSignupModal\" class=\"fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center\" style=\"z-index: 1000;\" @click.self=\"showSignupModal = false\">")
-                                 (:div :class "card" :style "max-width: 400px; width: 100%; margin: 20px;"
-                                       (:h2 :style "font-size: 1.5rem; font-weight: 600; margin-bottom: 20px; color: var(--text-primary);" "Sign Up")
-                                       (:raw "<form @submit.prevent=\"signup\">")
-                                       (:input :class "form-control" :style "margin-bottom: 15px;" :v-model "signupForm.username" :placeholder "Username (3-50 characters)" :required "required")
-                                       (:input :class "form-control" :style "margin-bottom: 15px;" :type "email" :v-model "signupForm.email" :placeholder "Email" :required "required")
-                                       (:input :class "form-control" :style "margin-bottom: 15px;" :type "password" :v-model "signupForm.password" :placeholder "Password (min 8 characters)" :required "required")
-                                       (:input :class "form-control" :style "margin-bottom: 15px;" :v-model "signupForm.display_name" :placeholder "Display Name (optional)")
-                                       (:div :style "display: flex; gap: 10px;"
-                                             (:button :class "btn btn-gradient" :type "submit" :style "flex: 1;" "Sign Up")
-                                             (:button :class "btn btn-outline" :type "button" :style "flex: 1;" "@click" "showSignupModal = false" "Cancel"))
-                                       (:raw "</form>"))
-                                 (:raw "</div>"))
-                           (:script :src "/static/js/app.js")))))
+;;; ログイン・サインアップページ
+
+(define-easy-handler (login-page :uri "/login") ()
+                     "ログインページ"
+                     (setf (content-type*) "text/html")
+                     (with-html-string
+                       (:doctype)
+                       (:html :lang "ja"
+                         (:head
+                           (:meta :charset "utf-8")
+                           (:meta :name "viewport" :content "width=device-width, initial-scale=1.0")
+                           (:title "ログイン - Common Lisp Blog")
+                           (:link :rel "stylesheet" :href "/static/css/login.css"))
+                         (:body :class "login-page"
+                           (:div :class "background")
+
+                           (:div :class "login-header"
+                                 (:div :class "logo"
+                                       (:div :class "logo-icon" "B")
+                                       (:span :class "logo-text" "Common Lisp Blog"))
+                                 (:a :href "/signup" :class "signup-btn" "新規登録"))
+
+                           (:div :class "container"
+                                 (:div :class "login-card"
+                                       (:h1 :class "brand-name" "MyBlog")
+                                       (:p :class "brand-subtitle" "ログインしてブログを書こう")
+
+                                       (:div :id "error-message" :class "error-message" :style "display: none;")
+
+                                       (:form :id "login-form" :action "/api/auth/login" :method "post"
+                                             (:div :class "form-group"
+                                                   (:input :type "text"
+                                                           :name "username"
+                                                           :class "form-input"
+                                                           :placeholder "ユーザー名"
+                                                           :required "required"))
+
+                                             (:div :class "form-group"
+                                                   (:input :type "password"
+                                                           :name "password"
+                                                           :class "form-input"
+                                                           :placeholder "パスワード"
+                                                           :required "required"))
+
+                                             (:button :type "submit" :class "login-btn" "ログイン"))
+
+                                       (:div :class "switch-link"
+                                             "アカウントをお持ちでない方は "
+                                             (:a :href "/signup" "新規登録"))))
+
+                           (:script :src "/static/js/login.js")))))
+
+(define-easy-handler (signup-page :uri "/signup") ()
+                     "サインアップページ"
+                     (setf (content-type*) "text/html")
+                     (with-html-string
+                       (:doctype)
+                       (:html :lang "ja"
+                         (:head
+                           (:meta :charset "utf-8")
+                           (:meta :name "viewport" :content "width=device-width, initial-scale=1.0")
+                           (:title "新規登録 - Common Lisp Blog")
+                           (:link :rel "stylesheet" :href "/static/css/login.css"))
+                         (:body :class "login-page"
+                           (:div :class "background")
+
+                           (:div :class "login-header"
+                                 (:div :class "logo"
+                                       (:div :class "logo-icon" "B")
+                                       (:span :class "logo-text" "Common Lisp Blog"))
+                                 (:a :href "/login" :class "login-btn-header" "ログイン"))
+
+                           (:div :class "container"
+                                 (:div :class "login-card"
+                                       (:h1 :class "brand-name" "MyBlog")
+                                       (:p :class "brand-subtitle" "アカウントを作成")
+
+                                       (:div :id "error-message" :class "error-message" :style "display: none;")
+                                       (:div :id "success-message" :class "success-message" :style "display: none;")
+
+                                       (:form :id "signup-form" :action "/api/auth/signup" :method "post"
+                                             (:div :class "form-group"
+                                                   (:input :type "text"
+                                                           :name "username"
+                                                           :class "form-input"
+                                                           :placeholder "ユーザー名 (3-50文字)"
+                                                           :required "required"
+                                                           :minlength "3"
+                                                           :maxlength "50"))
+
+                                             (:div :class "form-group"
+                                                   (:input :type "email"
+                                                           :name "email"
+                                                           :class "form-input"
+                                                           :placeholder "メールアドレス"
+                                                           :required "required"))
+
+                                             (:div :class "form-group"
+                                                   (:input :type "password"
+                                                           :name "password"
+                                                           :class "form-input"
+                                                           :placeholder "パスワード (8文字以上)"
+                                                           :required "required"
+                                                           :minlength "8"))
+
+                                             (:div :class "form-group"
+                                                   (:input :type "text"
+                                                           :name "display-name"
+                                                           :class "form-input"
+                                                           :placeholder "表示名 (任意)"))
+
+                                             (:button :type "submit" :class "login-btn" "アカウント作成"))
+
+                                       (:div :class "switch-link"
+                                             "すでにアカウントをお持ちの方は "
+                                             (:a :href "/login" "ログイン"))))
+
+                           (:script :src "/static/js/login.js")))))

--- a/static/css/admin-card-layout.css
+++ b/static/css/admin-card-layout.css
@@ -68,6 +68,8 @@ body.admin-layout {
   font-size: 0.9rem;
   font-weight: 500;
   transition: all 0.2s;
+  text-decoration: none;
+  display: inline-block;
 }
 
 .btn-outline {

--- a/static/css/login.css
+++ b/static/css/login.css
@@ -1,0 +1,267 @@
+/* Login/Signup Page CSS - Based on /docs/login-mockups/blog_login_mock.html */
+
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+body.login-page {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, sans-serif;
+    height: 100vh;
+    overflow: hidden;
+}
+
+.background {
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    background-size: cover;
+    background-position: center;
+    filter: brightness(0.8);
+    z-index: -1;
+}
+
+.login-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 20px 40px;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+}
+
+.logo {
+    display: flex;
+    align-items: center;
+    gap: 15px;
+}
+
+.logo-icon {
+    width: 35px;
+    height: 35px;
+    background: white;
+    border-radius: 8px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: bold;
+    font-size: 20px;
+    color: #667eea;
+}
+
+.logo-text {
+    color: white;
+    font-size: 20px;
+    font-weight: 600;
+}
+
+.signup-btn {
+    background: #00d084;
+    color: white;
+    border: none;
+    padding: 10px 25px;
+    border-radius: 6px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background 0.3s;
+    text-decoration: none;
+    display: inline-block;
+}
+
+.signup-btn:hover {
+    background: #00b872;
+}
+
+.login-btn-header {
+    background: transparent;
+    color: white;
+    border: 2px solid white;
+    padding: 10px 25px;
+    border-radius: 6px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: all 0.3s;
+    text-decoration: none;
+    display: inline-block;
+}
+
+.login-btn-header:hover {
+    background: white;
+    color: #667eea;
+}
+
+.container {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    min-height: 100vh;
+    padding: 20px;
+}
+
+.login-card {
+    background: white;
+    border-radius: 12px;
+    padding: 50px 40px;
+    width: 100%;
+    max-width: 420px;
+    box-shadow: 0 20px 60px rgba(0, 0, 0, 0.3);
+}
+
+.brand-name {
+    text-align: center;
+    font-size: 48px;
+    font-weight: bold;
+    color: #1a1a1a;
+    margin-bottom: 15px;
+    letter-spacing: -1px;
+}
+
+.brand-subtitle {
+    text-align: center;
+    font-size: 16px;
+    color: #666;
+    margin-bottom: 40px;
+}
+
+.form-group {
+    margin-bottom: 15px;
+}
+
+.form-label {
+    display: block;
+    font-size: 14px;
+    color: #333;
+    margin-bottom: 5px;
+    font-weight: 500;
+}
+
+.form-input {
+    width: 100%;
+    padding: 15px;
+    border: 1px solid #e0e0e0;
+    border-radius: 6px;
+    font-size: 15px;
+    transition: border-color 0.3s;
+    outline: none;
+}
+
+.form-input:focus {
+    border-color: #667eea;
+}
+
+.login-btn {
+    width: 100%;
+    padding: 15px;
+    background: #00d084;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    font-size: 16px;
+    font-weight: 600;
+    cursor: pointer;
+    margin-top: 10px;
+    transition: background 0.3s;
+}
+
+.login-btn:hover {
+    background: #00b872;
+}
+
+.forgot-password {
+    text-align: right;
+    margin-top: 10px;
+}
+
+.forgot-password a {
+    color: #667eea;
+    text-decoration: none;
+    font-size: 14px;
+}
+
+.forgot-password a:hover {
+    text-decoration: underline;
+}
+
+.divider {
+    display: flex;
+    align-items: center;
+    margin: 25px 0;
+    color: #888;
+    font-size: 14px;
+}
+
+.divider::before,
+.divider::after {
+    content: '';
+    flex: 1;
+    border-bottom: 1px solid #e0e0e0;
+}
+
+.divider::before {
+    margin-right: 15px;
+}
+
+.divider::after {
+    margin-left: 15px;
+}
+
+.switch-link {
+    text-align: center;
+    margin-top: 25px;
+}
+
+.switch-link a {
+    color: #667eea;
+    text-decoration: none;
+    font-size: 14px;
+    font-weight: 500;
+}
+
+.switch-link a:hover {
+    text-decoration: underline;
+}
+
+.error-message {
+    background: #fee;
+    color: #c33;
+    padding: 12px;
+    border-radius: 6px;
+    margin-bottom: 15px;
+    font-size: 14px;
+    text-align: center;
+}
+
+.success-message {
+    background: #efe;
+    color: #3c3;
+    padding: 12px;
+    border-radius: 6px;
+    margin-bottom: 15px;
+    font-size: 14px;
+    text-align: center;
+}
+
+/* Responsive Design */
+@media (max-width: 768px) {
+    .login-header {
+        padding: 15px 20px;
+    }
+
+    .login-card {
+        padding: 40px 30px;
+    }
+
+    .brand-name {
+        font-size: 36px;
+    }
+
+    .logo-text {
+        display: none;
+    }
+}

--- a/static/js/app.js
+++ b/static/js/app.js
@@ -11,18 +11,6 @@ const app = createApp({
         content: '',
         status: 'draft'
       },
-      loginForm: {
-        username: '',
-        password: ''
-      },
-      signupForm: {
-        username: '',
-        email: '',
-        password: '',
-        display_name: ''
-      },
-      showLoginModal: false,
-      showSignupModal: false
     }
   },
   
@@ -42,70 +30,7 @@ const app = createApp({
         console.error('認証チェックエラー:', error);
       }
     },
-    
-    async login() {
-      try {
-        const formData = new URLSearchParams();
-        formData.append('username', this.loginForm.username);
-        formData.append('password', this.loginForm.password);
-        
-        const response = await fetch('/api/auth/login', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
-          },
-          body: formData
-        });
-        
-        const result = await response.json();
-        
-        if (response.ok) {
-          alert('ログイン成功！');
-          this.showLoginModal = false;
-          this.loginForm = { username: '', password: '' };
-          await this.checkAuth();
-          await this.fetchPosts();
-        } else {
-          alert(result.message || 'ログインに失敗しました');
-        }
-      } catch (error) {
-        console.error('ログインエラー:', error);
-        alert('ログインに失敗しました');
-      }
-    },
-    
-    async signup() {
-      try {
-        const formData = new URLSearchParams();
-        formData.append('username', this.signupForm.username);
-        formData.append('email', this.signupForm.email);
-        formData.append('password', this.signupForm.password);
-        formData.append('display-name', this.signupForm.display_name || this.signupForm.username);
-        
-        const response = await fetch('/api/auth/signup', {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/x-www-form-urlencoded',
-          },
-          body: formData
-        });
-        
-        const result = await response.json();
-        
-        if (response.ok) {
-          alert('アカウント作成成功！ログインしてください。');
-          this.showSignupModal = false;
-          this.signupForm = { username: '', email: '', password: '', display_name: '' };
-          this.showLoginModal = true;
-        } else {
-          alert(result.message || 'アカウント作成に失敗しました');
-        }
-      } catch (error) {
-        console.error('サインアップエラー:', error);
-        alert('アカウント作成に失敗しました');
-      }
-    },
-    
+
     async logout() {
       try {
         await fetch('/api/auth/logout', { method: 'POST' });

--- a/static/js/login.js
+++ b/static/js/login.js
@@ -1,0 +1,97 @@
+// Login and Signup Page JavaScript
+
+document.addEventListener('DOMContentLoaded', function() {
+    const loginForm = document.getElementById('login-form');
+    const signupForm = document.getElementById('signup-form');
+    const errorMessage = document.getElementById('error-message');
+    const successMessage = document.getElementById('success-message');
+
+    // Login Form Handler
+    if (loginForm) {
+        loginForm.addEventListener('submit', async function(e) {
+            e.preventDefault();
+
+            const formData = new FormData(loginForm);
+            const data = new URLSearchParams(formData);
+
+            try {
+                const response = await fetch('/api/auth/login', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded',
+                    },
+                    body: data
+                });
+
+                const result = await response.json();
+
+                if (response.ok) {
+                    // ログイン成功 - メインページにリダイレクト
+                    window.location.href = '/';
+                } else {
+                    // エラー表示
+                    showError(result.error || result.message || 'ログインに失敗しました');
+                }
+            } catch (error) {
+                console.error('Login error:', error);
+                showError('ログインに失敗しました。もう一度お試しください。');
+            }
+        });
+    }
+
+    // Signup Form Handler
+    if (signupForm) {
+        signupForm.addEventListener('submit', async function(e) {
+            e.preventDefault();
+
+            const formData = new FormData(signupForm);
+            const data = new URLSearchParams(formData);
+
+            try {
+                const response = await fetch('/api/auth/signup', {
+                    method: 'POST',
+                    headers: {
+                        'Content-Type': 'application/x-www-form-urlencoded',
+                    },
+                    body: data
+                });
+
+                const result = await response.json();
+
+                if (response.ok) {
+                    // サインアップ成功
+                    showSuccess('アカウントが作成されました！ログインページに移動します...');
+                    setTimeout(() => {
+                        window.location.href = '/login';
+                    }, 2000);
+                } else {
+                    // エラー表示
+                    showError(result.error || result.message || 'アカウント作成に失敗しました');
+                }
+            } catch (error) {
+                console.error('Signup error:', error);
+                showError('アカウント作成に失敗しました。もう一度お試しください。');
+            }
+        });
+    }
+
+    function showError(message) {
+        if (errorMessage) {
+            errorMessage.textContent = message;
+            errorMessage.style.display = 'block';
+            if (successMessage) {
+                successMessage.style.display = 'none';
+            }
+        }
+    }
+
+    function showSuccess(message) {
+        if (successMessage) {
+            successMessage.textContent = message;
+            successMessage.style.display = 'block';
+            if (errorMessage) {
+                errorMessage.style.display = 'none';
+            }
+        }
+    }
+});


### PR DESCRIPTION
## 概要

`/docs/login-mockups/blog_login_mock.html`のモックアップに基づいて、専用のログイン・サインアップページを実装しました。

## 変更内容

### 新規ファイル

#### 1. `static/css/login.css`
- モックアップに基づいたグラデーション背景デザイン
- パープル系グラデーション（`#667eea` → `#764ba2`）
- 中央配置の白いカード（影付き）
- フローティングヘッダー（ロゴ + アクションボタン）
- レスポンシブ対応

#### 2. `static/js/login.js`
- ログイン・サインアップフォームのハンドリング
- エラーメッセージ表示機能
- 成功時のリダイレクト処理
- サインアップ成功後の自動ログインページ遷移

#### 3. `docs/login-mockups/blog_login_mock.html`
- デザインモックアップ（参考資料として追加）

### 更新ファイル

#### 1. `src/handlers.lisp`
- `/login`ページハンドラー追加
- `/signup`ページハンドラー追加
- メインページのログイン・サインアップボタンを新しいページへのリンクに変更
- モーダルコード削除（28行削除）

#### 2. `static/js/app.js`
- `loginForm`、`signupForm`データ削除
- `showLoginModal`、`showSignupModal`フラグ削除
- `login()`、`signup()`メソッド削除（63行削除）
- コードの簡素化

#### 3. `static/css/admin-card-layout.css`
- `.btn`クラスに`text-decoration: none`と`display: inline-block`を追加
- `<a>`タグでも正しく表示されるように調整

## デザイン仕様

### カラーパレット
- **背景グラデーション**: `linear-gradient(135deg, #667eea 0%, #764ba2 100%)`
- **カード背景**: `white`
- **アクションボタン**: `#00d084`（緑）
- **アウトラインボタン**: 透明背景 + 白ボーダー
- **アクセントカラー**: `#667eea`（リンク、フォーカス時）

### レイアウト
- **ヘッダー**: 固定位置（top: 0）、両端揃え
- **カード**: 中央配置、最大幅420px、シャドウ付き
- **ブランド名**: 48px、太字、中央揃え
- **フォーム**: シンプルな入力フィールド、15pxパディング

## ユーザーエクスペリエンス

### ログインフロー
1. ユーザーが `/login` にアクセス
2. ユーザー名・パスワードを入力
3. ログインボタンをクリック
4. 成功時 → メインページ (`/`) にリダイレクト
5. 失敗時 → エラーメッセージ表示

### サインアップフロー
1. ユーザーが `/signup` にアクセス
2. ユーザー名・メール・パスワード・表示名を入力
3. アカウント作成ボタンをクリック
4. 成功時 → 成功メッセージ表示後、2秒後に `/login` へリダイレクト
5. 失敗時 → エラーメッセージ表示

### ページ間の移動
- ログインページ → 「新規登録」ボタン → サインアップページ
- サインアップページ → 「ログイン」ボタン → ログインページ
- メインページ → 「Login」/「Sign Up」ボタン → 各ページ

## 技術的改善

### コード削減
- **handlers.lisp**: モーダルHTML削除（28行）
- **app.js**: モーダル関連コード削除（70行以上）
- 合計**約100行のコード削減**

### パフォーマンス
- モーダル不要によりDOM要素の削減
- Vue.jsの不要なリアクティブデータ削除
- ページ読み込みの高速化

### 保守性
- 認証UIが独立したページとして分離
- 責任の明確化（メインページは投稿管理、ログインページは認証）
- CSSの再利用性向上

## テスト方法

1. サーバー起動
   ```bash
   sbcl --load main.lisp
   ```

2. ブラウザで `http://localhost:8080` にアクセス
3. 「Login」または「Sign Up」ボタンをクリック
4. 各ページで認証フローをテスト

## スクリーンショット

モックアップ: `docs/login-mockups/blog_login_mock.html`

## 破壊的変更

なし。既存のAPIと完全に互換性があります。

## チェックリスト

- [x] login.css作成
- [x] login.js作成  
- [x] /loginページ実装
- [x] /signupページ実装
- [x] メインページからモーダル削除
- [x] app.js清掃
- [x] レスポンシブ対応
- [x] エラーハンドリング

🤖 Generated with [Claude Code](https://claude.com/claude-code)